### PR TITLE
Add sprite asset guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,5 @@ After building, the executable will be placed inside the `build` directory. Run 
 Please see [AGENTS.md](AGENTS.md) for coding conventions and contribution guidelines.
 
 This repository follows the standard C++ layout with source files in `src/` and header files in `include/`.
+
+For sprite size and spritesheet layout recommendations, see [docs/asset_guidelines.md](docs/asset_guidelines.md).

--- a/docs/asset_guidelines.md
+++ b/docs/asset_guidelines.md
@@ -1,0 +1,16 @@
+# Asset Guidelines
+
+This document outlines best practices for preparing sprites and tiles for Zombie-Survival-2.0.
+
+## Sprite Tile Size
+
+- Use **64×64 pixel** tiles for most sprites.
+- Keep every frame or object within a 64×64 pixel box.
+
+## Spritesheet Layout
+
+- Arrange sprites in a grid of uniform rows and columns.
+- Reserve a small amount of empty space (1–2 pixels) between tiles to prevent bleeding when rendering.
+- Keep consistent padding around the edges of the spritesheet as well.
+
+Following these guidelines makes it easier to load graphics consistently and keeps animation frames aligned.


### PR DESCRIPTION
## Summary
- add docs/asset_guidelines.md with tile size and spritesheet layout info
- link to asset guidelines from README

## Testing
- `cmake -S . -B build` *(fails: does not appear to contain CMakeLists.txt)*
- `ctest --test-dir build` *(fails: build directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869ef353afc8330a230529550ecb931