### PR TITLE
Add SFML viewer with zombie sprite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 *.exe
 *.out
 *.app
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.10)
+project(ZombieSurvival VERSION 0.1)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+enable_testing()
+add_subdirectory(src)
+add_subdirectory(tests)

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ cmake --build .
 
 ## Running
 
-After building, the executable will be placed inside the `build` directory. Run it with:
+After building, the executable will be placed inside the `build` directory. Run it from the **project root** so the assets folder can be located:
 
 ```bash
 ./ZombieSurvival
 ```
-This will launch a window displaying the sample zombie sprite.
+This will launch a window displaying the sample zombie sprite scaled to 64x64 pixels and centered in the window.
 
 ## Coding Conventions
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ After building, the executable will be placed inside the `build` directory. Run 
 ```bash
 ./ZombieSurvival
 ```
+This will launch a window displaying the sample zombie sprite.
 
 ## Coding Conventions
 

--- a/include/zombie_viewer.h
+++ b/include/zombie_viewer.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <string>
+
+// Runs a simple SFML window that displays the given zombie sprite.
+void run_zombie_viewer(const std::string& sprite_path);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,10 @@
+find_package(SFML 2.5 COMPONENTS graphics window system REQUIRED)
+
+add_executable(ZombieSurvival
+    main.cpp
+    zombie_viewer.cpp
+)
+
+target_include_directories(ZombieSurvival PUBLIC ${PROJECT_SOURCE_DIR}/include)
+
+target_link_libraries(ZombieSurvival PRIVATE sfml-graphics sfml-window sfml-system)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,9 @@
+#include "zombie_viewer.h"
+
+// Entry point of the application.
+int main() {
+    // Path to the normal zombie sprite (variation 1)
+    const char* sprite_path = "assets/images/zombie/normal zombie/variation 1/Normal Zombie Sprite (Model).png";
+    run_zombie_viewer(sprite_path);
+    return 0;
+}

--- a/src/zombie_viewer.cpp
+++ b/src/zombie_viewer.cpp
@@ -1,0 +1,25 @@
+#include "zombie_viewer.h"
+#include <SFML/Graphics.hpp>
+
+// Opens an SFML window and displays the provided sprite until the window is closed.
+void run_zombie_viewer(const std::string& sprite_path) {
+    sf::RenderWindow window(sf::VideoMode(512, 512), "Zombie Sprite Viewer");
+    sf::Texture texture;
+    if (!texture.loadFromFile(sprite_path)) {
+        // Failed to load the texture; exit early
+        return;
+    }
+    sf::Sprite sprite(texture);
+
+    while (window.isOpen()) {
+        sf::Event event;
+        while (window.pollEvent(event)) {
+            if (event.type == sf::Event::Closed) {
+                window.close();
+            }
+        }
+        window.clear(sf::Color::Black);
+        window.draw(sprite);
+        window.display();
+    }
+}

--- a/src/zombie_viewer.cpp
+++ b/src/zombie_viewer.cpp
@@ -10,6 +10,15 @@ void run_zombie_viewer(const std::string& sprite_path) {
         return;
     }
     sf::Sprite sprite(texture);
+    // Scale the sprite so that it fits within a 64x64 pixel box
+    const float target_size = 64.0f;
+    sf::Vector2u tex_size = texture.getSize();
+    sprite.setScale(target_size / tex_size.x, target_size / tex_size.y);
+
+    // Center the sprite in the window
+    sprite.setPosition(
+        (window.getSize().x - target_size) / 2.0f,
+        (window.getSize().y - target_size) / 2.0f);
 
     while (window.isOpen()) {
         sf::Event event;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+enable_testing()
+find_package(SFML 2.5 COMPONENTS graphics REQUIRED)
+
+set(ASSET_PATH "${PROJECT_SOURCE_DIR}/assets/images/zombie/normal zombie/variation 1/Normal Zombie Sprite (Model).png")
+configure_file(asset_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/asset_config.h @ONLY)
+
+add_executable(asset_load_test asset_load.cpp)
+target_include_directories(asset_load_test PUBLIC ${PROJECT_SOURCE_DIR}/include ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(asset_load_test PRIVATE sfml-graphics)
+
+add_test(NAME asset_load COMMAND asset_load_test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,3 +9,9 @@ target_include_directories(asset_load_test PUBLIC ${PROJECT_SOURCE_DIR}/include 
 target_link_libraries(asset_load_test PRIVATE sfml-graphics)
 
 add_test(NAME asset_load COMMAND asset_load_test)
+
+add_executable(sprite_scale_test sprite_scale.cpp)
+target_include_directories(sprite_scale_test PUBLIC ${PROJECT_SOURCE_DIR}/include ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(sprite_scale_test PRIVATE sfml-graphics)
+
+add_test(NAME sprite_scale COMMAND sprite_scale_test)

--- a/tests/asset_config.h.in
+++ b/tests/asset_config.h.in
@@ -1,0 +1,2 @@
+#pragma once
+#define ASSET_PATH "@ASSET_PATH@"

--- a/tests/asset_load.cpp
+++ b/tests/asset_load.cpp
@@ -1,0 +1,17 @@
+#include "asset_config.h"
+#include <SFML/Graphics.hpp>
+#include <iostream>
+
+#ifndef ASSET_PATH
+#error "ASSET_PATH not defined"
+#endif
+
+int main() {
+    const char* sprite_path = ASSET_PATH;
+    sf::Image image;
+    if (!image.loadFromFile(sprite_path)) {
+        std::cerr << "Failed to load zombie sprite\n";
+        return 1;
+    }
+    return 0;
+}

--- a/tests/sprite_scale.cpp
+++ b/tests/sprite_scale.cpp
@@ -1,0 +1,25 @@
+#include "asset_config.h"
+#include <SFML/Graphics.hpp>
+#include <iostream>
+
+int main() {
+    // Use sf::Image to avoid opening a window while still retrieving the
+    // dimensions of the sprite sheet.
+    sf::Image image;
+    if (!image.loadFromFile(ASSET_PATH)) {
+        std::cerr << "Failed to load zombie sprite\n";
+        return 1;
+    }
+    const float target_size = 64.0f;
+    sf::Vector2u tex_size = image.getSize();
+    float scale_x = target_size / tex_size.x;
+    float scale_y = target_size / tex_size.y;
+
+    // After scaling, the sprite should be exactly 64x64 pixels.
+    if (static_cast<int>(tex_size.x * scale_x) != 64 ||
+        static_cast<int>(tex_size.y * scale_y) != 64) {
+        std::cerr << "Incorrect sprite size\n";
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add CMake build files and a minimal SFML app
- show the normal zombie sprite on screen
- add an asset load test
- document running the viewer in README

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6872e238469c833095bccc883deee4ac