### PR TITLE
Scale sprite to 64x64

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ cmake --build .
 
 ## Running
 
-After building, the executable will be placed inside the `build` directory. Run it with:
+After building, the executable will be placed inside the `build` directory. Run it from the **project root** so the assets folder can be located:
 
 ```bash
 ./ZombieSurvival
 ```
-This will launch a window displaying the sample zombie sprite.
+This will launch a window displaying the sample zombie sprite scaled to 64x64 pixels and centered in the window.
 
 ## Coding Conventions
 

--- a/src/zombie_viewer.cpp
+++ b/src/zombie_viewer.cpp
@@ -10,6 +10,15 @@ void run_zombie_viewer(const std::string& sprite_path) {
         return;
     }
     sf::Sprite sprite(texture);
+    // Scale the sprite so that it fits within a 64x64 pixel box
+    const float target_size = 64.0f;
+    sf::Vector2u tex_size = texture.getSize();
+    sprite.setScale(target_size / tex_size.x, target_size / tex_size.y);
+
+    // Center the sprite in the window
+    sprite.setPosition(
+        (window.getSize().x - target_size) / 2.0f,
+        (window.getSize().y - target_size) / 2.0f);
 
     while (window.isOpen()) {
         sf::Event event;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,3 +9,9 @@ target_include_directories(asset_load_test PUBLIC ${PROJECT_SOURCE_DIR}/include 
 target_link_libraries(asset_load_test PRIVATE sfml-graphics)
 
 add_test(NAME asset_load COMMAND asset_load_test)
+
+add_executable(sprite_scale_test sprite_scale.cpp)
+target_include_directories(sprite_scale_test PUBLIC ${PROJECT_SOURCE_DIR}/include ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(sprite_scale_test PRIVATE sfml-graphics)
+
+add_test(NAME sprite_scale COMMAND sprite_scale_test)

--- a/tests/sprite_scale.cpp
+++ b/tests/sprite_scale.cpp
@@ -1,0 +1,25 @@
+#include "asset_config.h"
+#include <SFML/Graphics.hpp>
+#include <iostream>
+
+int main() {
+    // Use sf::Image to avoid opening a window while still retrieving the
+    // dimensions of the sprite sheet.
+    sf::Image image;
+    if (!image.loadFromFile(ASSET_PATH)) {
+        std::cerr << "Failed to load zombie sprite\n";
+        return 1;
+    }
+    const float target_size = 64.0f;
+    sf::Vector2u tex_size = image.getSize();
+    float scale_x = target_size / tex_size.x;
+    float scale_y = target_size / tex_size.y;
+
+    // After scaling, the sprite should be exactly 64x64 pixels.
+    if (static_cast<int>(tex_size.x * scale_x) != 64 ||
+        static_cast<int>(tex_size.y * scale_y) != 64) {
+        std::cerr << "Incorrect sprite size\n";
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- scale zombie sprite to 64x64 pixels and center it
- add test verifying sprite scaling logic
- mention running the executable from project root in README

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_6872e9c037f8833099fc86e749771bf7