### PR TITLE
Add ruleset for main branch protection

### DIFF
--- a/.github/rulesets/main-branch-protection.yml
+++ b/.github/rulesets/main-branch-protection.yml
@@ -1,0 +1,16 @@
+version: 1
+rulesets:
+  - name: "main branch protection"
+    enforcement: active
+    conditions:
+      ref_name:
+        include:
+          - "refs/heads/main"
+    rules:
+      - type: required_status_checks
+        parameters:
+          required_checks:
+            - context: ci
+      - type: pull_request
+        parameters:
+          required_approving_review_count: 1

--- a/README.md
+++ b/README.md
@@ -44,3 +44,13 @@ Please see [AGENTS.md](AGENTS.md) for coding conventions and contribution guidel
 This repository follows the standard C++ layout with source files in `src/` and header files in `include/`.
 
 For sprite size and spritesheet layout recommendations, see [docs/asset_guidelines.md](docs/assets/asset_guidelines.md).
+
+## Branch Protection
+
+This repository includes a branch protection ruleset located at
+`.github/rulesets/main-branch-protection.yml`. The ruleset enforces pull
+requests and requires the CI workflow to pass before changes can be merged into
+the `main` branch.
+
+To enable these rules in your fork, import the YAML file into the **Rulesets**
+section of your repository settings on GitHub.


### PR DESCRIPTION
## Summary
- add `.github/rulesets/main-branch-protection.yml` with required PR reviews and CI check for `main`
- document ruleset setup in `README.md`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_6876e635330c8330a4cf4f13cd2646b5