### PR TITLE
feat: add automated code map generator

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md text eol=lf

--- a/.github/workflows/code-map.yml
+++ b/.github/workflows/code-map.yml
@@ -1,0 +1,24 @@
+name: Code Map
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "include/**"
+      - "src/**"
+      - "scripts/gen_code_map.py"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Generate code map
+        run: |
+          python scripts/gen_code_map.py > docs/code_map.md
+      - name: Require updated code_map.md
+        run: |
+          git diff --exit-code docs/code_map.md || (echo "::error::Run \`make codemap\` and commit the updated docs/code_map.md"; exit 1)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,16 +22,17 @@ This document provides basic project conventions for all contributors.
 1. Add new `.cpp` files to `src/` and corresponding headers to `include/`.
 2. Place new images or audio under `assets/`.
 3. Document significant changes in `docs/`.
-4. Add tests under `tests/` when introducing new features.
-5. Build using CMake:
+4. Run `make codemap` to update `docs/code_map.md` after modifying `docs/`, `include/`, or `src/`.
+5. Add tests under `tests/` when introducing new features.
+6. Build using CMake:
    ```bash
    cmake -S . -B build
    cmake --build build
    ```
-6. Run tests after building:
+7. Run tests after building:
    ```bash
    ctest --test-dir build
    ```
-7. Ensure all tests pass before submitting a pull request.
+8. Ensure all tests pass before submitting a pull request.
 
 These guidelines apply to both AI and human contributions.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: codemap
+codemap:
+	python scripts/gen_code_map.py > docs/code_map.md
+	@echo "Updated docs/code_map.md"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ This repository follows the standard C++ layout with source files in `src/` and 
 
 For sprite size and spritesheet layout recommendations, see [docs/asset_guidelines.md](docs/assets/asset_guidelines.md).
 
+## Code Map
+Run `make codemap` to regenerate `docs/code_map.md` after changes to `docs/`, `include/`, or `src/`. Pull requests touching these paths must include an updated code map.
+
+
 ## Branch Protection
 
 This repository includes a branch protection ruleset located at

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -36,22 +36,22 @@ src/
 ### `docs/ReadMe.md`
 Here is the area where all the ideas and features for the game would be.
 > `Here is the area where all the ideas and features for the game would be.`  
-> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/docs/ReadMe.md#L1
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/980151f2301bc27d46df660797d3b324db5b0493/docs/ReadMe.md#L1
 
 ### `docs/UI (Interface)/Main Menu`
 Main Menu:
 > `Main Menu:`  
-> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/docs/UI (Interface)/Main Menu#L1
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/d96ee7caa8ad4c9448323c90da7cf87d359ddfd6/docs/UI%20%28Interface%29/Main%20Menu#L1
 
 ### `docs/UI (Interface)/Sub Menu (Select Mode)`
 Sub Menu (After hitting Play Button in Main Menu):
 > `Sub Menu (After hitting Play Button in Main Menu):`  
-> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/docs/UI (Interface)/Sub Menu (Select Mode)#L1
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a4961f349603033f372c35684bda7e4322dc27d/docs/UI%20%28Interface%29/Sub%20Menu%20%28Select%20Mode%29#L1
 
 ### `docs/assets/asset_guidelines.md`
 # Asset Guidelines
 > `# Asset Guidelines`  
-> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/docs/assets/asset_guidelines.md#L1
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/4599768db1549c182f1b998ae84fcd166dbaf507/docs/assets/asset_guidelines.md#L1
 
 ### `docs/code_map.md`
 Documentation.
@@ -59,66 +59,66 @@ Documentation.
 ### `docs/inspirations/ideas`
 Inspirations:
 > `Inspirations:`  
-> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/docs/inspirations/ideas#L1
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/a76d78e0af0a31c0d17d5982c489433b63d93794/docs/inspirations/ideas#L1
 
 ### `docs/mechanics/General Premise`
 General Functionality and Purpose of Game:
 > `General Functionality and Purpose of Game:`  
-> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/docs/mechanics/General Premise#L1
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/0b07116cc921a39d44de1175614ef9cb1505c71d/docs/mechanics/General%20Premise#L1
 
 ### `docs/shop/Shop Community`
 Shop Community:
 > `Shop Community:`  
-> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/docs/shop/Shop Community#L1
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/10f576fb30d26541c82ef53299c18202998cd671/docs/shop/Shop%20Community#L1
 
 ### `docs/world/generation.md`
 # World Generation
 > `# World Generation`  
-> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/docs/world/generation.md#L1
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/3e2c77e085e087f5a9fb79bea48184356f074129/docs/world/generation.md#L1
 
 ### `docs/world/world_requirements.md`
 # World Requirements
 > `# World Requirements`  
-> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/docs/world/world_requirements.md#L1
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/8e0ecac3dd09dcc928d44c159d3f0c166326661b/docs/world/world_requirements.md#L1
 
 ### `include/README.md`
 This directory will contain the project's header files.
 > `This directory will contain the project's header files.`  
-> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/include/README.md#L1
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/fb2fdc58389ea7cc66f855dbc19834f2e410c66d/include/README.md#L1
 
 ### `include/zombie_viewer.h`
 pragma once include <string>
 > `#pragma once`  
-> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/include/zombie_viewer.h#L1-L2
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/f4adb5ee624ce4147977940139ef09b18128f15e/include/zombie_viewer.h#L1-L2
 
 ### `src/CMakeLists.txt`
 find_package(SFML 2.5 COMPONENTS graphics window system REQUIRED)
 > `find_package(SFML 2.5 COMPONENTS graphics window system REQUIRED)`  
-> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/src/CMakeLists.txt#L1
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/f4adb5ee624ce4147977940139ef09b18128f15e/src/CMakeLists.txt#L1
 
 ### `src/README.md`
 This directory will contain the project's source files.
 > `This directory will contain the project's source files.`  
-> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/src/README.md#L1
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/fb2fdc58389ea7cc66f855dbc19834f2e410c66d/src/README.md#L1
 
 ### `src/main.cpp`
 include "zombie_viewer.h"
 > `#include "zombie_viewer.h"`  
-> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/src/main.cpp#L1
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/f4adb5ee624ce4147977940139ef09b18128f15e/src/main.cpp#L1
 
 ### `src/zombie_viewer.cpp`
 include "zombie_viewer.h" include <SFML/Graphics.hpp>
 > `#include "zombie_viewer.h"`  
-> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/src/zombie_viewer.cpp#L1-L2
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/9e583a17e287537672f936ddb38caa3a65f1793f/src/zombie_viewer.cpp#L1-L2
 
 ## Cross-references (`#include "..."`)
 
 - `src/main.cpp` ➜ `zombie_viewer.h`  
   > `#include "zombie_viewer.h"`  
-  > https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/src/main.cpp#L1
+  > https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/f4adb5ee624ce4147977940139ef09b18128f15e/src/main.cpp#L1
 - `src/zombie_viewer.cpp` ➜ `zombie_viewer.h`  
   > `#include "zombie_viewer.h"`  
-  > https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/src/zombie_viewer.cpp#L1
+  > https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/9e583a17e287537672f936ddb38caa3a65f1793f/src/zombie_viewer.cpp#L1
 
 ## TODO / FIXME
 

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -1,0 +1,125 @@
+# Code Map (auto-generated)
+
+**Do not edit by hand. Run `make codemap` to regenerate.**
+
+## File tree (docs / include / src)
+```
+docs/
+include/
+src/
+  UI (Interface)/
+  assets/
+  inspirations/
+  mechanics/
+  shop/
+  world/
+  ReadMe.md
+  code_map.md
+    Main Menu
+    Sub Menu (Select Mode)
+    asset_guidelines.md
+    ideas
+    General Premise
+    Shop Community
+    generation.md
+    world_requirements.md
+  README.md
+  zombie_viewer.h
+  CMakeLists.txt
+  README.md
+  main.cpp
+  zombie_viewer.cpp
+```
+
+## Responsibilities
+
+### `docs/ReadMe.md`
+Here is the area where all the ideas and features for the game would be.
+> `Here is the area where all the ideas and features for the game would be.`  
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/docs/ReadMe.md#L1
+
+### `docs/UI (Interface)/Main Menu`
+Main Menu:
+> `Main Menu:`  
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/docs/UI (Interface)/Main Menu#L1
+
+### `docs/UI (Interface)/Sub Menu (Select Mode)`
+Sub Menu (After hitting Play Button in Main Menu):
+> `Sub Menu (After hitting Play Button in Main Menu):`  
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/docs/UI (Interface)/Sub Menu (Select Mode)#L1
+
+### `docs/assets/asset_guidelines.md`
+# Asset Guidelines
+> `# Asset Guidelines`  
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/docs/assets/asset_guidelines.md#L1
+
+### `docs/code_map.md`
+Documentation.
+
+### `docs/inspirations/ideas`
+Inspirations:
+> `Inspirations:`  
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/docs/inspirations/ideas#L1
+
+### `docs/mechanics/General Premise`
+General Functionality and Purpose of Game:
+> `General Functionality and Purpose of Game:`  
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/docs/mechanics/General Premise#L1
+
+### `docs/shop/Shop Community`
+Shop Community:
+> `Shop Community:`  
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/docs/shop/Shop Community#L1
+
+### `docs/world/generation.md`
+# World Generation
+> `# World Generation`  
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/docs/world/generation.md#L1
+
+### `docs/world/world_requirements.md`
+# World Requirements
+> `# World Requirements`  
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/docs/world/world_requirements.md#L1
+
+### `include/README.md`
+This directory will contain the project's header files.
+> `This directory will contain the project's header files.`  
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/include/README.md#L1
+
+### `include/zombie_viewer.h`
+pragma once include <string>
+> `#pragma once`  
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/include/zombie_viewer.h#L1-L2
+
+### `src/CMakeLists.txt`
+find_package(SFML 2.5 COMPONENTS graphics window system REQUIRED)
+> `find_package(SFML 2.5 COMPONENTS graphics window system REQUIRED)`  
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/src/CMakeLists.txt#L1
+
+### `src/README.md`
+This directory will contain the project's source files.
+> `This directory will contain the project's source files.`  
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/src/README.md#L1
+
+### `src/main.cpp`
+include "zombie_viewer.h"
+> `#include "zombie_viewer.h"`  
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/src/main.cpp#L1
+
+### `src/zombie_viewer.cpp`
+include "zombie_viewer.h" include <SFML/Graphics.hpp>
+> `#include "zombie_viewer.h"`  
+> https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/src/zombie_viewer.cpp#L1-L2
+
+## Cross-references (`#include "..."`)
+
+- `src/main.cpp` ➜ `zombie_viewer.h`  
+  > `#include "zombie_viewer.h"`  
+  > https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/src/main.cpp#L1
+- `src/zombie_viewer.cpp` ➜ `zombie_viewer.h`  
+  > `#include "zombie_viewer.h"`  
+  > https://github.com/ProgrammingWithYagle/Zombie-Survival-2.0/blob/5a8186664cb5808d4b1b04ea62afce649192ecc7/src/zombie_viewer.cpp#L1
+
+## TODO / FIXME
+
+_No TODO/FIXME found._

--- a/scripts/gen_code_map.py
+++ b/scripts/gen_code_map.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Generate a Markdown code map for the repository.
+
+This script scans the docs/, include/, and src/ directories to produce an
+overview of the project structure.  The output includes:
+    * a file tree
+    * a brief responsibility summary for each file
+    * cross-references via `#include "..."`
+    * a list of TODO/FIXME notes
+
+The result is written to stdout so it can be redirected to docs/code_map.md.
+"""
+import os, re, sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO_SLUG = "ProgrammingWithYagle/Zombie-Survival-2.0"
+
+# Prefer CI-provided SHA; fall back to local git
+def current_sha():
+    sha = os.environ.get("GITHUB_SHA")
+    if sha:
+        return sha.strip()
+    try:
+        import subprocess
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=ROOT).decode().strip()
+    except Exception:
+        return "main"  # last resort; less stable permalink
+
+def permalink(sha, rel_path, start, end=None):
+    anchor = f"#L{start}" if end is None or end == start else f"#L{start}-L{end}"
+    return f"https://github.com/{REPO_SLUG}/blob/{sha}/{rel_path}{anchor}"
+
+SCAN_DIRS = ["docs", "include", "src"]
+CODE_EXTS = {".c",".cc",".cpp",".h",".hpp",".hh",".ipp",".inl",".mm",".m",".rs",".py",".java",".js",".ts",".tsx",".cs",".go",".lua"}
+COMMENT_PREFIXES = ("//", "#")
+
+def read_text(p: Path):
+    try:
+        return p.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return ""
+
+def first_comment_block(p: Path, text: str):
+    # For code: capture leading // or /* */. For md/txt: first nonempty line.
+    if p.suffix in CODE_EXTS:
+        lines = text.splitlines()
+        block, start, end = [], None, None
+        i = 0
+        # line comments
+        while i < len(lines) and (lines[i].strip().startswith("//") or lines[i].strip().startswith("#")):
+            if start is None: start = i+1
+            block.append(lines[i].strip().lstrip("/#").strip())
+            end = i+1
+            i += 1
+        # block comment
+        if start is None and i < len(lines) and "/*" in lines[i]:
+            start = i+1
+            block.append(lines[i].strip())
+            i += 1
+            while i < len(lines):
+                block.append(lines[i].strip())
+                if "*/" in lines[i]:
+                    end = i+1
+                    break
+                i += 1
+        if start and end:
+            summary = " ".join(" ".join(block).split())
+            return summary[:200], start, end
+    # markdown/plain docs
+    for idx, line in enumerate(text.splitlines(), start=1):
+        if line.strip():
+            return line.strip()[:200], idx, idx
+    return None, None, None
+
+def derive_summary_from_path(p: Path):
+    if "UI (Interface)" in p.parts:
+        return "UI spec / screen outline.", None, None
+    if p.suffix == ".md":
+        return "Documentation.", None, None
+    if p.suffix in {".h",".hpp"}:
+        return "Header declarations.", None, None
+    if p.suffix in {".c",".cc",".cpp"}:
+        return "Source implementation.", None, None
+    return "File (needs description).", None, None
+
+include_re = re.compile(r'^\s*#include\s+"([^"]+)"')
+todo_re = re.compile(r'\b(TODO|FIXME)\b', re.IGNORECASE)
+
+def collect():
+    files = []
+    for d in SCAN_DIRS:
+        base = ROOT / d
+        if not base.exists(): continue
+        for p in sorted(base.rglob("*")):
+            if p.is_file():
+                rel = p.relative_to(ROOT).as_posix()
+                files.append((p, rel))
+    return files
+
+def build_tree(files):
+    # simple textual tree
+    lines = []
+    by_dir = {}
+    for _, rel in files:
+        parts = rel.split("/")
+        by_dir.setdefault(parts[0], []).append(parts[1:])
+    def walk(prefix, entries, depth=0):
+        dirs, leafs = {}, []
+        for parts in entries:
+            if len(parts) == 1:
+                leafs.append(parts[0])
+            else:
+                dirs.setdefault(parts[0], []).append(parts[1:])
+        indent = "  " * depth
+        if depth == 0:
+            for k in sorted(dirs): lines.append(f"{k}/")
+            for f in sorted(leafs): lines.append(f"{f}")
+        else:
+            for k in sorted(dirs): lines.append(f"{indent}{k}/")
+            for f in sorted(leafs): lines.append(f"{indent}{f}")
+        for k in sorted(dirs):
+            walk(prefix+[k], dirs[k], depth+1)
+    flat = [(p, rel) for p, rel in files]
+    walk([], [rel.split("/") for _, rel in flat], 0)
+    return lines
+
+def main():
+    sha = current_sha()
+    files = collect()
+    print("# Code Map (auto-generated)\n")
+    print("**Do not edit by hand. Run `make codemap` to regenerate.**\n")
+    print("## File tree (docs / include / src)\n```")
+    for line in build_tree(files):
+        print(line)
+    print("```\n")
+
+    print("## Responsibilities\n")
+    for p, rel in files:
+        text = read_text(p)
+        summary, s, e = first_comment_block(p, text)
+        if not summary:
+            summary, s, e = derive_summary_from_path(p)
+        print(f"### `{rel}`")
+        print(f"{summary}")
+        if s:
+            link = permalink(sha, rel, s, e)
+            # quote the first line of the block
+            block_first = text.splitlines()[s-1].strip()
+            print(f"> `{block_first}`  \n> {link}")
+        print()
+
+    print("## Cross-references (`#include \"...\"`)\n")
+    for p, rel in files:
+        if p.suffix not in CODE_EXTS: continue
+        lines = read_text(p).splitlines()
+        for i, line in enumerate(lines, start=1):
+            m = include_re.match(line)
+            if m:
+                target = m.group(1)
+                link = permalink(sha, rel, i)
+                print(f"- `{rel}` ➜ `{target}`  \n  > `{line.strip()}`  \n  > {link}")
+    print()
+
+    print("## TODO / FIXME\n")
+    any_todo = False
+    for p, rel in files:
+        text = read_text(p)
+        for i, line in enumerate(text.splitlines(), start=1):
+            if todo_re.search(line):
+                any_todo = True
+                link = permalink(sha, rel, i)
+                print(f"- `{rel}:{i}`  \n  > `{line.strip()}`  \n  > {link}")
+    if not any_todo:
+        print("_No TODO/FIXME found._")
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `gen_code_map.py` script and Makefile target to auto-generate docs/code_map.md
- enforce up-to-date code map via CI workflow
- document code map workflow in AGENTS and README

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`
- `make codemap`


------
https://chatgpt.com/codex/tasks/task_e_6897b49f7f0483308cec8e9036f0814d